### PR TITLE
 sistemato indice fuori i limiti dell'array - resolve #4

### DIFF
--- a/general_scheduling.h
+++ b/general_scheduling.h
@@ -83,7 +83,7 @@ void ordinamentoProcessiId(processo processiOrdinId[] ,processo processi[], int 
 		processiOrdinId[i] = processi[i];
 	}
 	for (int j = 0; j < numeroDiProcessi; j++){
-        for (int i = 0; i < numeroDiProcessi; i++){
+        for (int i = 0; i < numeroDiProcessi-1; i++){
             if (processiOrdinId[i].id > processiOrdinId[i + 1].id){
                 processo swap = processiOrdinId[i];
                 processiOrdinId[i] = processiOrdinId[i + 1];


### PR DESCRIPTION
```c++
void ordinamentoProcessiId(processo processiOrdinId[] ,processo processi[], int numeroDiProcessi){    
....
	for (int j = 0; j < numeroDiProcessi; j++){
        for (int i = 0; i < numeroDiProcessi ; i++){                         <====  i arriva a n-1 , l'ultimmo elemento 
            if (processiOrdinId[i].id > processiOrdinId[i + 1].id){      <====i+1 è fuori dei limiti dell'array
                processo swap = processiOrdinId[i];
                processiOrdinId[i] = processiOrdinId[i + 1];  <====== 
                processiOrdinId[i + 1] = swap; <========
......
}
```

Il combinato disposto delle modalità di allocazione delle variabili C++98 / C++11 e Windows/linux fa si che il programma avesse il comportamento visto. 
Corretto questo errore ( che è anche di logica/applicativa) il comportamento è uniforme.  